### PR TITLE
relax the permissions on manually sending a notification

### DIFF
--- a/src/main/java/com/ccl/grandcanyon/Reminders.java
+++ b/src/main/java/com/ccl/grandcanyon/Reminders.java
@@ -1,19 +1,26 @@
 package com.ccl.grandcanyon;
 
+import com.ccl.grandcanyon.types.Admin;
 import com.ccl.grandcanyon.types.Caller;
 import com.ccl.grandcanyon.types.ReminderStatus;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.*;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
 
 
 @Path("/reminders")
 public class Reminders {
+
+  @Context
+  ContainerRequestContext requestContext;
 
   /**
    * Generate on-demand reminder, for testing reminder delivery.
@@ -21,7 +28,6 @@ public class Reminders {
   @PUT
   @Path("{callerId}")
   @Produces(MediaType.APPLICATION_JSON)
-  @RolesAllowed(GCAuth.SUPER_ADMIN_ROLE)
   public Response sendReminder(
       @PathParam("callerId") int callerId)
       throws SQLException {
@@ -29,11 +35,23 @@ public class Reminders {
     Connection conn = SQLHelper.getInstance().getConnection();
     try {
       Caller caller = Callers.retrieveById(conn, callerId);
+      checkPermissions(caller.getDistrictId(), "send a call notification");
       ReminderStatus status = ReminderService.getInstance().sendReminder(conn, caller);
       return Response.ok(BooleanNode.valueOf(status.success())).build();
     }
     finally {
       conn.close();
+    }
+  }
+
+  private void checkPermissions(int districtId, String action) {
+    Admin currentUser = (Admin)requestContext.getProperty(GCAuth.CURRENT_PRINCIPAL);
+    if (!currentUser.isRoot()) {
+      Set<Integer> allowedDistricts = new HashSet<>(currentUser.getDistricts());
+      if (!allowedDistricts.contains(districtId)) {
+        throw new ForbiddenException(String.format(
+                "Permission denied to %s for this district.", action));
+      }
     }
   }
 }


### PR DESCRIPTION
Turns out that multiple district admins have wanted to use this to help them troubleshoot email addresses with callers.